### PR TITLE
Remove npgsql from postgresql mapping

### DIFF
--- a/data/postgresql/postgresql/purls.yml
+++ b/data/postgresql/postgresql/purls.yml
@@ -4,5 +4,4 @@ purls:
   - pkg:docker/postgres
   - pkg:github/postgres/postgres
   - pkg:gitlab/redhat/postgresql
-  - pkg:nuget/Npgsql
   - pkg:rpm/fedora/postgresql


### PR DESCRIPTION
Npgsql is the .NET data provider for PostgreSQL, but not PostgreSQL itself.