### PR TITLE
Fix tdm_project/tdm mapping

### DIFF
--- a/data/tdm_project/tdm/cpes.yml
+++ b/data/tdm_project/tdm/cpes.yml
@@ -1,2 +1,2 @@
 cpes:
-  - cpe:2.3:a:tdm_project:tdm:*:*:*:*:*:*:*:*
+  - cpe:2.3:a:tdm_project:tdm:2017-04-12:*:*:*:*:*:*:*

--- a/data/tdm_project/tdm/cpes.yml
+++ b/data/tdm_project/tdm/cpes.yml
@@ -1,2 +1,2 @@
 cpes:
-  - cpe:2.3:a:tdm_project:tdm:2017-04-12:*:*:*:*:*:*:*
+  - cpe:2.3:a:tdm_project:tdm:*:*:*:*:*:*:*:*

--- a/data/tdm_project/tdm/purls.yml
+++ b/data/tdm_project/tdm/purls.yml
@@ -1,9 +1,2 @@
 purls:
-  - pkg:deb/debian/python-tqdm
-  - pkg:deb/ubuntu/python-tqdm
-  - pkg:docker/tqdm/tqdm
-  - pkg:github/tqdm/tqdm
-  - pkg:pypi/tqdm
-  - pkg:rpm/fedora/python-tqdm
-  - pkg:rpm/opensuse/python-tqdm
-  - pkg:sourceforge/tqdm.mirror
+  - pkg:github/trollepierre/tdm

--- a/data/tdm_project/tdm/purls.yml
+++ b/data/tdm_project/tdm/purls.yml
@@ -1,2 +1,9 @@
 purls:
-  - pkg:github/trollepierre/tdm
+  - pkg:deb/debian/python-tqdm
+  - pkg:deb/ubuntu/python-tqdm
+  - pkg:docker/tqdm/tqdm
+  - pkg:github/tqdm/tqdm
+  - pkg:pypi/tqdm
+  - pkg:rpm/fedora/python-tqdm
+  - pkg:rpm/opensuse/python-tqdm
+  - pkg:sourceforge/tqdm.mirror


### PR DESCRIPTION
The tdm_project/tdm should be mapped on https://github.com/trollepierre/tdm project according NIST page, but in the purl2cpe it was confused with tqdm_project/tqdm, that is absolutely another project.

Info:
- https://nvd.nist.gov/products/cpe/detail/E920A8DB-2242-4776-844A-D042D6D6E275?namingFormat=2.3&orderBy=CPEURI&keyword=cpe%3A2.3%3Aa%3Atdm_project%3Atdm&status=FINAL.