### PR TITLE
Add purl mapping for cryptopp/crypto++

### DIFF
--- a/data/cryptopp/crypto++/purls.yml
+++ b/data/cryptopp/crypto++/purls.yml
@@ -1,6 +1,6 @@
 purls:
-  - pkg:deb/debian/libcrypto++
-  - pkg:deb/ubuntu/libcrypto++
+  - pkg:deb/debian/libcrypto%2B%2B
+  - pkg:deb/ubuntu/libcrypto%2B%2B
   - pkg:github/weidai11/cryptopp
   - pkg:rpm/fedora/cryptopp
   - pkg:rpm/opensuse/libcryptopp

--- a/data/cryptopp/crypto++/purls.yml
+++ b/data/cryptopp/crypto++/purls.yml
@@ -1,0 +1,6 @@
+purls:
+  - pkg:deb/debian/libcrypto++
+  - pkg:deb/ubuntu/libcrypto++
+  - pkg:github/weidai11/cryptopp
+  - pkg:rpm/fedora/cryptopp
+  - pkg:rpm/opensuse/libcryptopp


### PR DESCRIPTION
The NVD CPE dictionary contains 29 entries for `cpe:2.3:a:cryptopp:crypto\+\+` (referenced by CVEs such as CVE-2019-14318), but the dataset currently has no `cryptopp` vendor folder, so Crypto++ purls resolve to no CPE.

This adds `data/cryptopp/crypto++/purls.yml` with the upstream repository and the distro source packages:

- `pkg:deb/debian/libcrypto++` / `pkg:deb/ubuntu/libcrypto++` (source package `libcrypto++`)
- `pkg:github/weidai11/cryptopp` (upstream)
- `pkg:rpm/fedora/cryptopp`
- `pkg:rpm/opensuse/libcryptopp`

Per CONTRIBUTING, `cpes.yml` is not included — is that backfilled from the NVD load once the folder exists, or would you prefer it added to this PR?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Crypto++ package link entries for Debian and Ubuntu to use properly URL-encoded “++” values, improving link correctness.
* **Documentation**
  * Refreshed package URL metadata for Crypto++ (GitHub, Fedora, and openSUSE remain unchanged).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->